### PR TITLE
BP-4439: Set scale when pages are loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12696,7 +12696,7 @@
         },
         "packages/vue-pdf-viewer": {
             "name": "@certifaction/vue-pdf-viewer",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "license": "MIT",
             "dependencies": {
                 "@certifaction/pdfjs": "^1.3.0",

--- a/packages/vue-pdf-viewer/src/components/PDFViewer.vue
+++ b/packages/vue-pdf-viewer/src/components/PDFViewer.vue
@@ -166,14 +166,6 @@ export default {
             eventBus
         })
 
-        eventBus.on('pagesinit', () => {
-            if (this.defaultScale) {
-                this.currentScale = this.defaultScale
-            }
-
-            this.pdfViewer.currentScaleValue = this.currentScale
-        })
-
         const docOptions = {
             cMapUrl: this.pdfjsCMapUrl,
             cMapPacked: true
@@ -192,6 +184,8 @@ export default {
         window.dispatchEvent(event)
 
         eventBus.on('pagesloaded', function() {
+            this.pdfViewer.currentScaleValue = this.currentScale = this.defaultScale
+
             const event = new Event('PDFViewer:pagesLoaded')
             window.dispatchEvent(event)
         })


### PR DESCRIPTION
In case of `defaultScale = 'page-width'` it doesn't work. I guess the reason is that the page width isn't known at the point when it needed to be set in the `pagesinit `listener. So I moved the initial setting of the scale to the `pagesloaded` listener