### PR TITLE
DT-257: form filling required fields

### DIFF
--- a/packages/vue-pdf-viewer/src/components/PdfViewer.vue
+++ b/packages/vue-pdf-viewer/src/components/PdfViewer.vue
@@ -136,7 +136,7 @@ export default {
             const scrollbarWidth = this.$refs.viewerContainer.offsetWidth - this.$refs.viewerContainer.clientWidth
             this.$refs.viewerControls.style.width = `calc(100% - ${scrollbarWidth}px)`
 
-            if (await this.pdfJsHelper.hasForm(this.pdfDocument)) {
+            if (await this.pdfJsHelper.hasForm(this.pdfDocument) && this.pdfjsViewerOptions.annotationMode === 2) {
               await this.prepareRequiredFormFields()
             }
         },

--- a/packages/vue-pdf-viewer/src/components/PdfViewer.vue
+++ b/packages/vue-pdf-viewer/src/components/PdfViewer.vue
@@ -154,20 +154,20 @@ export default {
 
                     const eventListener = async (event) => {
                         this.updateField(formField.id, formField.fieldName, event.target.type, event.target)
-                        const formIsValid = await this.pdfJsHelper.validateRequiredFields(
+                        const allRequiredFieldsFilled = await this.pdfJsHelper.allRequiredFieldsFilled(
                             this.transformedRequiredFormFieldsFilled,
                         )
-                        this.$emit('required-fields-filled', formIsValid)
+                        this.$emit('required-fields-filled', allRequiredFieldsFilled)
                     }
 
                     htmlElement.addEventListener('input', eventListener)
                     this.formEventListeners.push({ element: htmlElement, listener: eventListener })
                 })
 
-                const formIsValid = await this.pdfJsHelper.validateRequiredFields(
+                const allRequiredFieldsFilled = await this.pdfJsHelper.allRequiredFieldsFilled(
                     this.transformedRequiredFormFieldsFilled,
                 )
-                this.$emit('required-fields-filled', formIsValid)
+                this.$emit('required-fields-filled', allRequiredFieldsFilled)
             }
         },
         async updateField(fieldId, fieldName, fieldType, htmlElement) {

--- a/packages/vue-pdf-viewer/src/components/PdfViewer.vue
+++ b/packages/vue-pdf-viewer/src/components/PdfViewer.vue
@@ -136,51 +136,51 @@ export default {
             const scrollbarWidth = this.$refs.viewerContainer.offsetWidth - this.$refs.viewerContainer.clientWidth
             this.$refs.viewerControls.style.width = `calc(100% - ${scrollbarWidth}px)`
 
-            if (await this.pdfJsHelper.hasForm(this.pdfDocument) && this.pdfjsViewerOptions.annotationMode === 2) {
-              await this.prepareRequiredFormFields()
+            if ((await this.pdfJsHelper.hasForm(this.pdfDocument)) && this.pdfjsViewerOptions.annotationMode === 2) {
+                await this.prepareRequiredFormFields()
             }
         },
-      async prepareRequiredFormFields() {
-          const requiredFormFields = await this.pdfJsHelper.getRequiredFormFields(this.pdfDocument)
+        async prepareRequiredFormFields() {
+            const requiredFormFields = await this.pdfJsHelper.getRequiredFormFields(this.pdfDocument)
 
-          if (requiredFormFields?.length > 0) {
-              requiredFormFields.forEach((formField) => {
-                  const htmlElement = document.querySelector(`[data-element-id="${formField.id}"]`)
-                  this.updateField(formField.id, formField.fieldName, htmlElement.type, htmlElement)
+            if (requiredFormFields?.length > 0) {
+                requiredFormFields.forEach((formField) => {
+                    const htmlElement = document.querySelector(`[data-element-id="${formField.id}"]`)
+                    this.updateField(formField.id, formField.fieldName, htmlElement.type, htmlElement)
 
-                  htmlElement.addEventListener('input', async (event) => {
-                    this.updateField(formField.id, formField.fieldName, event.target.type, event.target)
-                    const formIsValid = await this.validateReactiveFormFields()
-                    this.$emit('required-fields-filled', formIsValid)
-                  })
-              })
+                    htmlElement.addEventListener('input', async (event) => {
+                        this.updateField(formField.id, formField.fieldName, event.target.type, event.target)
+                        const formIsValid = await this.validateReactiveFormFields()
+                        this.$emit('required-fields-filled', formIsValid)
+                    })
+                })
 
-              const formIsValid = await this.validateReactiveFormFields()
-              this.$emit('required-fields-filled', formIsValid)
-          }
-      },
-      async updateField(fieldId, fieldName, fieldType, htmlElement) {
-          let fieldValue
+                const formIsValid = await this.validateReactiveFormFields()
+                this.$emit('required-fields-filled', formIsValid)
+            }
+        },
+        async updateField(fieldId, fieldName, fieldType, htmlElement) {
+            let fieldValue
 
-          switch(fieldType) {
-              case 'radio':
-              case 'checkbox':
-                fieldValue = htmlElement.checked
-                break
-              default:
-                fieldValue = htmlElement.value
-                break
-          }
+            switch (fieldType) {
+                case 'radio':
+                case 'checkbox':
+                    fieldValue = htmlElement.checked
+                    break
+                default:
+                    fieldValue = htmlElement.value
+                    break
+            }
 
-          this.$set(this.requiredFormFieldsFilled, fieldId, { fieldName, fieldValue})
-      },
-      async validateReactiveFormFields() {
-          const transformedRequiredFields = Object.keys(this.requiredFormFieldsFilled).map(key => {
-              return { fieldId: key, ...this.requiredFormFieldsFilled[key] };
-          })
+            this.$set(this.requiredFormFieldsFilled, fieldId, { fieldName, fieldValue })
+        },
+        async validateReactiveFormFields() {
+            const transformedRequiredFields = Object.keys(this.requiredFormFieldsFilled).map((key) => {
+                return { fieldId: key, ...this.requiredFormFieldsFilled[key] }
+            })
 
-          return await this.pdfJsHelper.validateRequiredFields(this.pdfDocument, transformedRequiredFields)
-      }
+            return await this.pdfJsHelper.validateRequiredFields(this.pdfDocument, transformedRequiredFields)
+        },
     },
     created() {
         this.pdfJsHelper = PdfJsHelper.getInstance(this.pdfjsCMapUrl)

--- a/packages/vue-pdf-viewer/src/pdf/PdfJsHelper.js
+++ b/packages/vue-pdf-viewer/src/pdf/PdfJsHelper.js
@@ -166,9 +166,9 @@ export class PdfJsHelper {
         const requiredFormFields = []
 
         for (let i = 1; i <= pageCount; i++) {
-            const page = await pdfDocument.getPage(i);
+            const page = await pdfDocument.getPage(i)
             const annotations = await page.getAnnotations()
-            Object.values(annotations).forEach(annotation => {
+            Object.values(annotations).forEach((annotation) => {
                 if (annotation.required && annotation.subtype === 'Widget') {
                     requiredFormFields.push(annotation)
                 }
@@ -181,7 +181,7 @@ export class PdfJsHelper {
     /**
      * @param {PDFDocumentProxy} pdfDocument
      * @param {RequiredField[]} requiredFields
-     * @returns {Promise<Boolean>}
+     * @returns {Promise<boolean>}
      */
     async validateRequiredFields(pdfDocument, requiredFields) {
         if (!(await this.hasForm(pdfDocument))) {
@@ -193,7 +193,9 @@ export class PdfJsHelper {
         requiredFields.forEach((requiredField) => {
             // Groups like choices have the same fieldName, so there just one needs to be selected
             const sameFieldNameFields = requiredFields.filter((ff) => ff.fieldName === requiredField.fieldName)
-            const isEmpty = sameFieldNameFields.every(ff => ff.fieldValue === null || ff.fieldValue === false || ff.fieldValue === "")
+            const isEmpty = sameFieldNameFields.every(
+                (ff) => ff.fieldValue === null || ff.fieldValue === false || ff.fieldValue === '',
+            )
             if (isEmpty) {
                 hasEmptyRequiredFields = true
             }

--- a/packages/vue-pdf-viewer/src/pdf/PdfJsHelper.js
+++ b/packages/vue-pdf-viewer/src/pdf/PdfJsHelper.js
@@ -155,7 +155,7 @@ export class PdfJsHelper {
 
     /**
      * @param {PDFDocumentProxy} pdfDocument
-     * @returns {Promise<Array>}
+     * @returns {Promise<Array<any>>}
      */
     async getRequiredFormFields(pdfDocument) {
         if (!(await this.hasForm(pdfDocument))) {
@@ -182,7 +182,7 @@ export class PdfJsHelper {
      * @param {RequiredField[]} requiredFields
      * @returns {Promise<boolean>}
      */
-    async validateRequiredFields(requiredFields) {
+    async allRequiredFieldsFilled(requiredFields) {
         let hasEmptyRequiredFields = false
 
         requiredFields.forEach((requiredField) => {

--- a/packages/vue-pdf-viewer/src/pdf/PdfJsHelper.js
+++ b/packages/vue-pdf-viewer/src/pdf/PdfJsHelper.js
@@ -179,15 +179,10 @@ export class PdfJsHelper {
     }
 
     /**
-     * @param {PDFDocumentProxy} pdfDocument
      * @param {RequiredField[]} requiredFields
      * @returns {Promise<boolean>}
      */
-    async validateRequiredFields(pdfDocument, requiredFields) {
-        if (!(await this.hasForm(pdfDocument))) {
-            return true
-        }
-
+    async validateRequiredFields(requiredFields) {
         let hasEmptyRequiredFields = false
 
         requiredFields.forEach((requiredField) => {

--- a/packages/vue-pdf-viewer/src/pdf/PdfJsHelper.js
+++ b/packages/vue-pdf-viewer/src/pdf/PdfJsHelper.js
@@ -6,6 +6,14 @@
  */
 
 /**
+ * Manual type definition for parameter "RequiredField"
+ * @typedef {Object} RequiredField
+ * @property {string} fieldName
+ * @property {string | boolean} fieldValue
+ * @property {string} [fieldId]
+ */
+
+/**
  * Manual type definition for EventBus "pagesloaded"
  * @typedef {Object} PagesLoadedEvent
  * @property {PDFViewer} source
@@ -143,6 +151,55 @@ export class PdfJsHelper {
         const currentFormValues = pdfDocument.annotationStorage.getAll()
 
         return currentFormValues !== null
+    }
+
+    /**
+     * @param {PDFDocumentProxy} pdfDocument
+     * @returns {Promise<Array>}
+     */
+    async getRequiredFormFields(pdfDocument) {
+        if (!(await this.hasForm(pdfDocument))) {
+            return []
+        }
+
+        const pageCount = pdfDocument.numPages
+        const requiredFormFields = []
+
+        for (let i = 1; i <= pageCount; i++) {
+            const page = await pdfDocument.getPage(i);
+            const annotations = await page.getAnnotations()
+            Object.values(annotations).forEach(annotation => {
+                if (annotation.required && annotation.subtype === 'Widget') {
+                    requiredFormFields.push(annotation)
+                }
+            })
+        }
+
+        return requiredFormFields
+    }
+
+    /**
+     * @param {PDFDocumentProxy} pdfDocument
+     * @param {RequiredField[]} requiredFields
+     * @returns {Promise<Boolean>}
+     */
+    async validateRequiredFields(pdfDocument, requiredFields) {
+        if (!(await this.hasForm(pdfDocument))) {
+            return true
+        }
+
+        let hasEmptyRequiredFields = false
+
+        requiredFields.forEach((requiredField) => {
+            // Groups like choices have the same fieldName, so there just one needs to be selected
+            const sameFieldNameFields = requiredFields.filter((ff) => ff.fieldName === requiredField.fieldName)
+            const isEmpty = sameFieldNameFields.every(ff => ff.fieldValue === null || ff.fieldValue === false || ff.fieldValue === "")
+            if (isEmpty) {
+                hasEmptyRequiredFields = true
+            }
+        })
+
+        return !hasEmptyRequiredFields
     }
 
     /**


### PR DESCRIPTION
We only have access to required information through each pages annotation and input htmlElement. The idea is to get and check all required fields if they are filled. To check them reactivity was added to the required input fields and get checked on every input change. This will trigger an event which is listened on the signing page to disable/enable the signing button.

Since we cannot check for required fields for all documents immediately we decided to disable the sign button by default and the user needs to check each document for required fields before signing.

Requirement for: https://github.com/certifaction/certifaction-web/pull/1363