### PR TITLE
export optimize deps

### DIFF
--- a/packages/vue-pdf-viewer/src/vite/optimize_deps.d.ts
+++ b/packages/vue-pdf-viewer/src/vite/optimize_deps.d.ts
@@ -1,0 +1,5 @@
+declare const optimizeDeps: {
+    include: string[]
+}
+
+export default optimizeDeps

--- a/packages/vue-pdf-viewer/src/vite/optimize_deps.js
+++ b/packages/vue-pdf-viewer/src/vite/optimize_deps.js
@@ -1,0 +1,7 @@
+import packageJson from '../../package.json' with { type: 'json' }
+
+const dependencies = Object.keys(packageJson.dependencies)
+
+export default {
+    include: dependencies,
+}


### PR DESCRIPTION
As we exclude the package (@certifaction/vue-pdf-viewer) from being optimized in the vite config, it's better to include it's dependencies again, so they are being optimized.