### PR TITLE
DT-608: fix Firefox ESR problem

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
             "devDependencies": {
                 "@certifaction/prettier-config": "^8.0.0",
                 "@vue/eslint-config-prettier": "^10.1.0",
-                "eslint": "^9.14.0",
-                "eslint-plugin-vue": "^9.30.0",
+                "eslint": "^9.15.0",
+                "eslint-plugin-vue": "^9.31.0",
                 "lerna": "^8.1.9",
                 "prettier": "^3.3.3"
             }
@@ -169,9 +169,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-            "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
+            "integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -184,9 +184,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-            "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
+            "integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -194,9 +194,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-            "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+            "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -218,9 +218,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.14.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
-            "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+            "version": "9.15.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
+            "integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -238,9 +238,9 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-            "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+            "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -1007,9 +1007,9 @@
             }
         },
         "node_modules/@nx/devkit": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.0.10.tgz",
-            "integrity": "sha512-GcIAQ11JrcONZpn3tIU5mtLzx9j8UMdpjns0r6yMiW7k0z6SwK5+hxIkNQJ86mndjSqiY1EdUK629tz0UscacQ==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/devkit/-/devkit-20.1.2.tgz",
+            "integrity": "sha512-MTEWiEST7DhzZ2QmrixLnHfYVDZk7QN9omLL8m+5Etcn/3ZKa1aAo9Amd2MkUM+0MPoTKnxoGdw0fQUpAy21Mg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1053,9 +1053,9 @@
             }
         },
         "node_modules/@nx/nx-darwin-arm64": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.0.10.tgz",
-            "integrity": "sha512-fa2coWtz4wUwsB5Zpi47FEgdiKn5Bn4jVYsN37BE+wci1GpoxqhQOGgl0Hgv3KTjQfw9mEmvPT701QZcZBsetA==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-20.1.2.tgz",
+            "integrity": "sha512-PJ91TQhd28kitDBubKUOXMYvrtSDrG+rr8MsIe9cHo1CvU9smcGVBwuHBxniq0DXsyOX/5GL6ngq7hjN2nQ3XQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1070,9 +1070,9 @@
             }
         },
         "node_modules/@nx/nx-darwin-x64": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.0.10.tgz",
-            "integrity": "sha512-LIsFeOEt1PKybhIpSJuMoBXe7ID5pBJa2w4SfiGeD9+mv3dAp/COJ9+XYeWA1HpTMgY0nOabfi1bMqzezFt/fg==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-20.1.2.tgz",
+            "integrity": "sha512-1fopau7nxIhTF26vDTIzMxl15AtW4FvUSdy+r1mNRKrKyjjpqnlu00SQBW7JzGV0agDD1B/61yYei5Q2aMOt7Q==",
             "cpu": [
                 "x64"
             ],
@@ -1087,9 +1087,9 @@
             }
         },
         "node_modules/@nx/nx-freebsd-x64": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.0.10.tgz",
-            "integrity": "sha512-q1LTJlazM35PGjJIBLIXOFLjuR8y0R7BIEu1LTJPIsQEshJSlEUzQUocT2k51HB54OdFQG7Xhu0aMDzfCqU3ag==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-20.1.2.tgz",
+            "integrity": "sha512-55YgIp3v4zz7xMzJO93dtglbOTER2XdS6jrCt8GbKaWGFl5drRrBoNGONtiGNU7C3hLx1VsorbynCkJT18PjKQ==",
             "cpu": [
                 "x64"
             ],
@@ -1104,9 +1104,9 @@
             }
         },
         "node_modules/@nx/nx-linux-arm-gnueabihf": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.0.10.tgz",
-            "integrity": "sha512-fVphTD459f7ogzcADDGLR3Ot7v7ApWTLeL9vw0j95Kza3sBWHE1hYIlzHwOANLkdzy5lxtSo44XIvNuTRkingg==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-20.1.2.tgz",
+            "integrity": "sha512-sMhNA8uAV43UYVEXEa8TZ8Fjpom4CGq1umTptEGOF4TTtdNn2AUBreg+0bVODM8MMSzRWGI1VbkZzHESnAPwqw==",
             "cpu": [
                 "arm"
             ],
@@ -1121,9 +1121,9 @@
             }
         },
         "node_modules/@nx/nx-linux-arm64-gnu": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.0.10.tgz",
-            "integrity": "sha512-BPAA5vzoEuKjPDXMqocOXS2SuvxfqpL/YCbMNtFt/PK1lzYijxaFY6L+00fIauKFv+99dG8e/IPf0Y3ze5pw4g==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-20.1.2.tgz",
+            "integrity": "sha512-bsevarNHglaYLmIvPNQOdHrBnBgaW3EOUM0flwaXdWuZbL1bWx8GoVwHp9yJpZOAOfIF/Nhq5iTpaZB2nYFrAA==",
             "cpu": [
                 "arm64"
             ],
@@ -1138,9 +1138,9 @@
             }
         },
         "node_modules/@nx/nx-linux-arm64-musl": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.0.10.tgz",
-            "integrity": "sha512-9tUBJk45kMAbW3v3q42WtufYd2OwlrlH/MBemEEve78eRr/SYnpFKsdQC2snJOy8bzE4JoG91vMBoSw9a0X/ng==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-20.1.2.tgz",
+            "integrity": "sha512-GFZTptkhZPL/iZ3tYDmspIcPEaXyy/L/o59gyp33GoFAAyDhiXIF7J1Lz81Xn8VKrX6TvEY8/9qSh86pb7qzDQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1155,9 +1155,9 @@
             }
         },
         "node_modules/@nx/nx-linux-x64-gnu": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.0.10.tgz",
-            "integrity": "sha512-7D10+bJvAbqDp/r3hIaZFbq8kPIgnpPiJ37I2E8EHNSGsmRUAkM33zkF2FfTHpiLIlsKvqr+UNADwV2fLBYzAw==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-20.1.2.tgz",
+            "integrity": "sha512-yqEW/iglKT4d9lgfnwSNhmDzPxCkRhtdmZqOYpGDM0eZFwYwJF+WRGjW8xIqMj8PA1yrGItzXZOmyFjJqHAF2w==",
             "cpu": [
                 "x64"
             ],
@@ -1172,9 +1172,9 @@
             }
         },
         "node_modules/@nx/nx-linux-x64-musl": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.0.10.tgz",
-            "integrity": "sha512-cI6wNpWPFgEnzdMGpUd459bas+hJYT+vjdcwcQ9piCNwBroKgZK67SZFxf+7sL6yhUFRydDyFCalyubGE/hlrQ==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-20.1.2.tgz",
+            "integrity": "sha512-SP6PpWT4cQVrC4WJQdpfADrYJQzkbhgmcGleWbpr7II1HJgOsAcvoDwQGpPQX+3Wo+VBiNecvUAOzacMQkXPGw==",
             "cpu": [
                 "x64"
             ],
@@ -1189,9 +1189,9 @@
             }
         },
         "node_modules/@nx/nx-win32-arm64-msvc": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.0.10.tgz",
-            "integrity": "sha512-/N2somgmYfwrGNRJpu7c6S+98xqvBImXKF5iZt0aA9wyYnjJ18gA3AiI/nyGbayAstzSSg7hwMMnEZfw9pifdg==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-20.1.2.tgz",
+            "integrity": "sha512-JZQx9gr39LY3D7uleiXlpxUsavuOrOQNBocwKHkAMnykaT/e1VCxTnm/hk+2b4foWwfURTqoRiFEba70iiCdYg==",
             "cpu": [
                 "arm64"
             ],
@@ -1206,9 +1206,9 @@
             }
         },
         "node_modules/@nx/nx-win32-x64-msvc": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.0.10.tgz",
-            "integrity": "sha512-38NGZjq53W0hF6YDXRB+FTrzbF+3XZoeea2nU/C5HBw9MeiSgLsAjpMsL7YlcmFyvwY/BTIWQITCrwVUhPF/BA==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-20.1.2.tgz",
+            "integrity": "sha512-6GmT8iswDiCvJaCtW9DpWeAQmLS/kfAuRLYBisfzlONuLPaDdjhgVIxZBqqUSFfclwcVz+NhIOGvdr0aGFZCtQ==",
             "cpu": [
                 "x64"
             ],
@@ -2640,9 +2640,9 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.4.tgz",
-            "integrity": "sha512-9KdyVPPtLHjPAD7tcuzSFs64UfHlLJt7U6qP4/bFVLyjLceyizj6s6jO6YBaV5d0G7g/9KnY/dOpLR4Rcg8YDg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2904,13 +2904,13 @@
             }
         },
         "node_modules/dotenv-expand": {
-            "version": "11.0.6",
-            "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.6.tgz",
-            "integrity": "sha512-8NHi73otpWsZGBSZwwknTXS5pqMOrk9+Ssrna8xCaxkzEpU9OTf9R5ArQGVw03//Zmk9MOwLPng9WwndvpAJ5g==",
+            "version": "11.0.7",
+            "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+            "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "dotenv": "^16.4.4"
+                "dotenv": "^16.4.5"
             },
             "engines": {
                 "node": ">=12"
@@ -3068,27 +3068,27 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.14.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
-            "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
+            "version": "9.15.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
+            "integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.18.0",
-                "@eslint/core": "^0.7.0",
-                "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "9.14.0",
-                "@eslint/plugin-kit": "^0.2.0",
+                "@eslint/config-array": "^0.19.0",
+                "@eslint/core": "^0.9.0",
+                "@eslint/eslintrc": "^3.2.0",
+                "@eslint/js": "9.15.0",
+                "@eslint/plugin-kit": "^0.2.3",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.4.0",
+                "@humanwhocodes/retry": "^0.4.1",
                 "@types/estree": "^1.0.6",
                 "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
+                "cross-spawn": "^7.0.5",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^8.2.0",
@@ -3107,8 +3107,7 @@
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.3",
-                "text-table": "^0.2.0"
+                "optionator": "^0.9.3"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
@@ -3173,9 +3172,9 @@
             }
         },
         "node_modules/eslint-plugin-vue": {
-            "version": "9.30.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.30.0.tgz",
-            "integrity": "sha512-CyqlRgShvljFkOeYK8wN5frh/OGTvkj1S7wlr2Q2pUvwq+X5VYiLd6ZjujpgSgLnys2W8qrBLkXQ41SUYaoPIQ==",
+            "version": "9.31.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-9.31.0.tgz",
+            "integrity": "sha512-aYMUCgivhz1o4tLkRHj5oq9YgYPM4/EJc0M7TAKRLCUA5OYxRLAhYEVD2nLtTwLyixEFI+/QXSvKU9ESZFgqjQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3603,9 +3602,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-            "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+            "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
             "dev": true,
             "license": "ISC"
         },
@@ -5087,9 +5086,9 @@
             }
         },
         "node_modules/libnpmpublish/node_modules/ci-info": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
-            "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+            "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
             "dev": true,
             "funding": [
                 {
@@ -6136,9 +6135,9 @@
             }
         },
         "node_modules/nx": {
-            "version": "20.0.10",
-            "resolved": "https://registry.npmjs.org/nx/-/nx-20.0.10.tgz",
-            "integrity": "sha512-QcPWtyfA8B0AevLLmWLmOwRXAeelpSx3osEBqpLJgsNnpd1XOq/dLUQwSOOFFTLaWVkukU3qRanE5ReTllj+2Q==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/nx/-/nx-20.1.2.tgz",
+            "integrity": "sha512-CvjmuQmI0RWLYZxRSIgQZmzsQv6dPp9oI0YZE3L1dagBPfTf5Cun65I0GLt7bdkDnVx2PGYkDbIoJSv2/V+83Q==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -6181,16 +6180,16 @@
                 "nx-cloud": "bin/nx-cloud.js"
             },
             "optionalDependencies": {
-                "@nx/nx-darwin-arm64": "20.0.10",
-                "@nx/nx-darwin-x64": "20.0.10",
-                "@nx/nx-freebsd-x64": "20.0.10",
-                "@nx/nx-linux-arm-gnueabihf": "20.0.10",
-                "@nx/nx-linux-arm64-gnu": "20.0.10",
-                "@nx/nx-linux-arm64-musl": "20.0.10",
-                "@nx/nx-linux-x64-gnu": "20.0.10",
-                "@nx/nx-linux-x64-musl": "20.0.10",
-                "@nx/nx-win32-arm64-msvc": "20.0.10",
-                "@nx/nx-win32-x64-msvc": "20.0.10"
+                "@nx/nx-darwin-arm64": "20.1.2",
+                "@nx/nx-darwin-x64": "20.1.2",
+                "@nx/nx-freebsd-x64": "20.1.2",
+                "@nx/nx-linux-arm-gnueabihf": "20.1.2",
+                "@nx/nx-linux-arm64-gnu": "20.1.2",
+                "@nx/nx-linux-arm64-musl": "20.1.2",
+                "@nx/nx-linux-x64-gnu": "20.1.2",
+                "@nx/nx-linux-x64-musl": "20.1.2",
+                "@nx/nx-win32-arm64-msvc": "20.1.2",
+                "@nx/nx-win32-x64-msvc": "20.1.2"
             },
             "peerDependencies": {
                 "@swc-node/register": "^1.8.0",
@@ -6672,9 +6671,9 @@
             }
         },
         "node_modules/path2d": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.1.tgz",
-            "integrity": "sha512-Fl2z/BHvkTNvkuBzYTpTuirHZg6wW9z8+4SND/3mDTEcYbbNKWAy21dz9D3ePNNwrrK8pqZO5vLPZ1hLF6T7XA==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.2.tgz",
+            "integrity": "sha512-+vnG6S4dYcYxZd+CZxzXCNKdELYZSKfohrk98yajCo1PtRoDgCTrrwOvK1GT0UoAdVszagDVllQc0U1vaX4NUQ==",
             "license": "MIT",
             "optional": true,
             "engines": {
@@ -6797,9 +6796,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.47",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-            "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+            "version": "8.4.49",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+            "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
             "dev": true,
             "funding": [
                 {
@@ -6818,7 +6817,7 @@
             "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.3.7",
-                "picocolors": "^1.1.0",
+                "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
             "engines": {
@@ -8243,13 +8242,6 @@
             "engines": {
                 "node": ">=0.10"
             }
-        },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/through": {
             "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
     "devDependencies": {
         "@certifaction/prettier-config": "^8.0.0",
         "@vue/eslint-config-prettier": "^10.1.0",
-        "eslint": "^9.14.0",
-        "eslint-plugin-vue": "^9.30.0",
+        "eslint": "^9.15.0",
+        "eslint-plugin-vue": "^9.31.0",
         "lerna": "^8.1.9",
         "prettier": "^3.3.3"
     },
     "volta": {
-        "node": "23.1.0"
+        "node": "23.3.0"
     }
 }

--- a/packages/vue-pdf-viewer/src/pdf/PdfJsHelper.js
+++ b/packages/vue-pdf-viewer/src/pdf/PdfJsHelper.js
@@ -40,8 +40,6 @@
 export class PdfJsHelper {
     /** @type {Promise<boolean>} */
     #initialized
-    /** @type {boolean} */
-    #useLegacyPdfJsBuild = false
     /** @type {string} */
     #pdfjsCMapUrl
 
@@ -49,8 +47,8 @@ export class PdfJsHelper {
      * @param {string} pdfjsCMapUrl
      */
     constructor(pdfjsCMapUrl) {
-        if (typeof Promise.withResolvers !== 'function') {
-            this.#useLegacyPdfJsBuild = true
+        if (globalThis.useLegacyPdfJsBuild === undefined) {
+            globalThis.useLegacyPdfJsBuild = typeof Promise.withResolvers !== 'function'
         }
         this.#pdfjsCMapUrl = pdfjsCMapUrl
 
@@ -61,7 +59,7 @@ export class PdfJsHelper {
      * @returns {Promise<boolean>}
      */
     async #init() {
-        if (this.#useLegacyPdfJsBuild) {
+        if (globalThis.useLegacyPdfJsBuild) {
             const { GlobalWorkerOptions } = await import('pdfjs-dist/legacy/build/pdf.mjs')
             GlobalWorkerOptions.workerPort = new Worker(
                 new URL('pdfjs-dist/legacy/build/pdf.worker.min.mjs', import.meta.url),
@@ -85,7 +83,7 @@ export class PdfJsHelper {
     async loadDocument(source) {
         await this.#initialized
 
-        const { getDocument } = this.#useLegacyPdfJsBuild
+        const { getDocument } = globalThis.useLegacyPdfJsBuild
             ? await import('pdfjs-dist/legacy/build/pdf.mjs')
             : await import('pdfjs-dist')
 
@@ -204,7 +202,7 @@ export class PdfJsHelper {
     async createPdfViewer(pdfjsViewerOptions, viewerContainer, viewer) {
         await this.#initialized
 
-        const { EventBus, PDFViewer } = this.#useLegacyPdfJsBuild
+        const { EventBus, PDFViewer } = globalThis.useLegacyPdfJsBuild
             ? await import('pdfjs-dist/legacy/web/pdf_viewer.mjs')
             : await import('pdfjs-dist/web/pdf_viewer.mjs')
 


### PR DESCRIPTION
PDF.js seems to polyfill `Promise.withResolvers` when the legacy version gets loaded. That causes the non-legacy version to get loaded when the PdfJsHelper gets instantiated the 2nd time.